### PR TITLE
Rename pypiwin32 to pywin32 in setup.cfg for conda-forge.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,11 @@ package:
 source:
   url: https://github.com/colcon/{{ name }}/archive/{{ version }}.tar.gz
   sha256: c8679b59985dfdca2c0707f4f58313013bc2ef52e9ec8c101e285b431c490d15
+  patches:
+    - pypiwin32.dist.patch
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . -vv"
   skip: True  # [py<35 or osx or unix]
 

--- a/recipe/pypiwin32.dist.patch
+++ b/recipe/pypiwin32.dist.patch
@@ -1,0 +1,17 @@
+--- setup.cfg
++++ setup - Copy.cfg
+@@ -25,13 +25,13 @@
+ keywords = colcon
+ 
+ [options]
+ install_requires =
+   colcon-core>=0.3.7
+   notify2; sys_platform == 'linux'
+-  pypiwin32; sys_platform == 'win32'
++  pywin32; sys_platform == 'win32'
+ packages = find:
+ tests_require =
+   flake8
+   flake8-blind-except
+   flake8-builtins
+   flake8-class-newline


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This is to make `colcon-notificaiton` usable on `conda-forge` for Windows. Without the patch, the `colcon build` will throw the following errors:

```
[2.040s] colcon.colcon_core.entry_point ERROR Exception loading extension 'colcon_core.event_handler.terminal_title': The 'pypiwin32; sys_platform == "win32"' distribution was not found and is required by the application
Traceback (most recent call last):
  File "C:\Users\xxx\AppData\Local\Continuum\miniconda3\envs\yyy\lib\site-packages\colcon_core\entry_point.py", line 98, in load_entry_points
    extension_type = load_entry_point(entry_point)
  File "C:\Users\xxx\AppData\Local\Continuum\miniconda3\envs\yyy\lib\site-packages\colcon_core\entry_point.py", line 140, in load_entry_point
    return entry_point.load()
  File "C:\Users\xxx\AppData\Local\Continuum\miniconda3\envs\yyy\lib\site-packages\pkg_resources\__init__.py", line 2442, in load
    self.require(*args, **kwargs)
  File "C:\Users\xxx\AppData\Local\Continuum\miniconda3\envs\yyy\lib\site-packages\pkg_resources\__init__.py", line 2465, in require
    items = working_set.resolve(reqs, env, installer, extras=self.extras)
  File "C:\Users\xxx\AppData\Local\Continuum\miniconda3\envs\yyy\lib\site-packages\pkg_resources\__init__.py", line 786, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'pypiwin32; sys_platform == "win32"' distribution was not found and is required by the application
```

On `conda-forge`, the `pypiwin32` is packaged as `pywin32` and it seems when `load_entry_points` checks the dependencies, it still honors the dependencies name in `setup.cfg`. I am not sure if any better ways other than patching the `setup.cfg`. However, this band-aid fix makes the problem going away.
